### PR TITLE
Chování knihovny v případě chyby

### DIFF
--- a/fakturoid.php
+++ b/fakturoid.php
@@ -185,12 +185,11 @@ class Fakturoid {
     }    
     
     $response = curl_exec($c);
-	$info = curl_getinfo($c);
+    $info = curl_getinfo($c);
     
-	if ($info['http_code'] >= 400) {
+    if ($info['http_code'] >= 400) {
       throw new Exception($response, $info['http_code']); 
-    }
-	
+    }	
     curl_close($c);
     return json_decode($response);
   }


### PR DESCRIPTION
Commit (SHA 2664e3ef3f7240d026a482569fad30e320ec399e) umožnil dostat se k chybové hlášce v případě chybného požadavku (HTTP_CODE >=400) Nyní jsou však tyto řádky zbytečné:

if ($response === FALSE) {
    throw new Exception(curl_error($c));
}

neboť $response nebude nikdy FALSE a výjimka tak nebude vyhozena.

Moje úprava vrací chování knihovny zpět (tj. vyhodí výjimku v případě chyby), ale zároveň umožňuje dostat se k chybové hlášce / chybovým hláškám přes Exception::getMessage(); a k chybovému kódu přes Exception::getCode();

Berte prosím jen jako návrh, hlavní moje motivace pro úpravu byla vyzkoušet si práci s Gitem :-)
