### PR TITLE
Send PHP version in a request header.

### DIFF
--- a/lib/Fakturoid/Request.php
+++ b/lib/Fakturoid/Request.php
@@ -47,7 +47,7 @@ class Request
         curl_setopt($c, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($c, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($c, CURLOPT_USERAGENT, $this->getHeader('User-Agent'));
-        curl_setopt($c, CURLOPT_HTTPHEADER, $this->filterHeaders());
+        curl_setopt($c, CURLOPT_HTTPHEADER, $this->getHttpHeaders());
 
         $headers = array();
 
@@ -130,9 +130,11 @@ class Request
     }
 
     // User-Agent header is sent differently.
-    private function filterHeaders()
+    public function getHttpHeaders()
     {
-        $headers = array();
+        $headers = array(
+            'X-Client-Env: PHP ' . PHP_VERSION
+        );
 
         foreach ($this->headers as $name => $value) {
             if (strtolower($name) != 'user-agent') {

--- a/tests/Fakturoid/RequestTest.php
+++ b/tests/Fakturoid/RequestTest.php
@@ -63,4 +63,20 @@ class RequestTest extends TestCase
         $this->assertEquals('Test <test@example.org>', $request->getHeader('user-agent'));
         $this->assertEquals('Test <test@example.org>', $request->getHeader('uSeR-aGeNt'));
     }
+
+    public function testGetHttpHeaders()
+    {
+        $request = new Request(array(
+            'url'     => 'https://app.fakturoid.cz/api/v2/accounts/invoices.json',
+            'method'  => 'get',
+            'userpwd' => 'test:123456',
+            'headers' => array(
+                'User-Agent' => 'Test <test@example.org>'
+            )
+        ));
+        $headers   = $request->getHttpHeaders();
+        $clientEnv = $headers[0];
+
+        $this->assertRegExp('/PHP \d+\.\d+\.\d+/', $clientEnv);
+    }
 }


### PR DESCRIPTION
Knowing which version of PHP people use will allow us to make judgement about minimum PHP version of this library - we don't want it to be too archaic but also don't want to prevent people from upgrading.