### PR TITLE
#34 Fix oauth token refresh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
   "require-dev": {
     "ext-dom": "*",
     "ext-mbstring": "*",
-    "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan": "^1.11",
     "phpunit/phpunit": "^10.5",
-    "rector/rector": "^0.19.2",
+    "rector/rector": "^1.0",
     "squizlabs/php_codesniffer": "^3.7",
     "guzzlehttp/guzzle": "^7.8"
   },


### PR DESCRIPTION
Closes: #34 

Is possible to check by 


```php
<?php

require_once __DIR__ . '/vendor/autoload.php';

$manager = new \Fakturoid\FakturoidManager(
    client: new \GuzzleHttp\Client(),
    clientId: '',
    clientSecret: '',
    userAgent: '',
    accountSlug: null,
    redirectUri: ''
);

$credentials = new \Fakturoid\Auth\Credentials(
    refreshToken: '',
    accessToken: ',
    expireAt: (new \DateTimeImmutable())->modify('-2 minutes'),
    authType: \Fakturoid\Enum\AuthTypeEnum::AUTHORIZATION_CODE_FLOW
);

$manager->setCredentials($credentials);
$manager->setAccountSlug('');

var_dump($manager->getUsersProvider()->getCurrentUser());
var_dump($manager->getUsersProvider()->getCurrentUser()); 
```