### PR TITLE
Adding PHP 8.5 to the controlled versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
     needs: composer
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
       fail-fast: false
     name: "Check by PHP version"
 


### PR DESCRIPTION
I think it will be good for the future to detect some problems and BC breaks in advance.

PHP 8.5 will not be released until 20.11.2025