### PR TITLE
Add count method to Response class

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -6,7 +6,7 @@ use Fakturoid\Exception\InvalidResponseException;
 use JsonException;
 use Psr\Http\Message\ResponseInterface;
 
-class Response
+class Response implements \Countable
 {
     private readonly int $statusCode;
     /** @var array<string, mixed> */

--- a/src/Response.php
+++ b/src/Response.php
@@ -78,4 +78,19 @@ class Response
         $contentType = $this->getHeader('Content-Type');
         return $contentType !== null && str_contains($contentType, 'application/json');
     }
+
+    /**
+     * @throws InvalidResponseException
+     */
+    public function count(): int
+    {
+        $body = $this->getBody();
+        if (is_array($body)) {
+            return count($body);
+        }
+        if ($body instanceof \Countable) {
+            return count($body);
+        }
+        return 0;
+    }
 }


### PR DESCRIPTION
Introduces a count() method to the Response class, allowing retrieval of the count of items in the response body if it is an array or implements Countable. Returns 0 otherwise.