### PR TITLE
Enhance rate limit handling and update response types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## next
-- Add support for actions on recurring invoices.
-- Add support for rate limit headers
+## 5.0.0
+- Add support for actions on recurring invoices (`pause()`, `activate()`).
+- Add support for rate limit headers.
+- **BREAKING CHANGE**: `RequestException::getResponse()` now returns `Fakturoid\Response` instead of `Psr\Http\Message\ResponseInterface`.
+  - This change allows for easier access to rate limiting information from exceptions.
+  - If you were type-hinting `ResponseInterface` when catching exceptions, you need to update your code.
+  - See [UPGRADE.md](UPGRADE.md) for migration guide.
 
 ## 4.0.0
 - Remove user agent in favor of PSR-18 client configuration and add better documentation for ClientInterface.

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ When the rate limit is exceeded, the server responds with status code `429 Too M
 
 ## Handling errors
 
-Library raises `Fakturoid\Exception\ClientErrorException` for `4xx` and `Fakturoid\Exception\ServerErrorException` for `5xx` status. You can get response code and response body by calling `getCode()` or `getResponse()->getBody()`.
+Library raises `Fakturoid\Exception\ClientErrorException` for `4xx` and `Fakturoid\Exception\ServerErrorException` for `5xx` status. You can get response code and response body by calling `getCode()` or `getResponse()->getBody()` or `getResponse()->getBody()` or `getResponse()->getBody()`.
 
 ```php
 try {
@@ -458,7 +458,7 @@ try {
 } catch (\Fakturoid\Exception\ClientErrorException $e) {
     $e->getCode(); // 422
     $e->getMessage(); // Unprocessable entity
-    $e->getResponse()->getBody()->getContents(); // '{"errors":{"name":["je povinná položka","je příliš krátký/á/é (min. 2 znaků)"]}}'
+    $e->getResponse()->getBody(); // '{"errors":{"name":["je povinná položka","je příliš krátký/á/é (min. 2 znaků)"]}}'
 } catch (\Fakturoid\Exception\ServerErrorException $e) {
     $e->getCode(); // 503
     $e->getMessage(); // Fakturoid is in read only state

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 PHP library for [Fakturoid.cz](https://www.fakturoid.cz/). Please see [API](https://www.fakturoid.cz/api/v3) for more documentation.
 New account just for testing API and using separate user (created via "Settings > User account") for production usage is highly recommended.
 
+> **⚠️ Upgrading?** See [UPGRADE.md](UPGRADE.md) for breaking changes and migration guide.
 
 ## Content
 
@@ -43,6 +44,7 @@ New account just for testing API and using separate user (created via "Settings 
 
 | Lib. version  | Fakturoid API | PHP            |
 |---------------|---------------|----------------|
+| `5.x`         | `v3`          | `>=8.2`        |
 | `4.x`         | `v3`          | `>=8.2`        |
 | `3.x`         | `v3`          | `>=8.2`        |
 | `2.x`         | `v3`          | `>=8.1`        |
@@ -414,28 +416,36 @@ $fManager->getRecurringGeneratorsProvider()->activate($generatorId, [
 Fakturoid implements rate limiting based on RFC Draft. The library provides methods to check rate limit status from the response object:
 
 ```php
-$response = $fManager->getInvoicesProvider()->list();
-
-// Get maximum number of requests allowed in the time window
-$quota = $response->getRateLimitQuota(); // e.g., 400
-
-// Get time window in seconds
-$window = $response->getRateLimitWindow(); // e.g., 60
-
-// Get remaining number of requests
-$remaining = $response->getRateLimitRemaining(); // e.g., 398
-
-// Get remaining time in seconds until the rate limit resets
-$resetTime = $response->getRateLimitReset(); // e.g., 55
-
-// Check if rate limit was exceeded (status code 429)
-if ($response->isRateLimitExceeded()) {
-    // Wait until the rate limit resets
-    sleep($response->getRateLimitReset());
+try {
+    $response = $fManager->getInvoicesProvider()->list();
+    
+    // Get maximum number of requests allowed in the time window
+    $quota = $response->getRateLimitQuota(); // e.g., 400
+    
+    // Get time window in seconds
+    $window = $response->getRateLimitWindow(); // e.g., 60
+    
+    // Get remaining number of requests
+    $remaining = $response->getRateLimitRemaining(); // e.g., 398
+    
+    // Get remaining time in seconds until the rate limit resets
+    $resetTime = $response->getRateLimitReset(); // e.g., 55
+    
+} catch (\Fakturoid\Exception\ClientErrorException $exception) {
+    // Check if rate limit was exceeded (status code 429)
+    if ($exception->isRateLimitExceeded()) {
+        // Access rate limit info from the exception's response
+        $response = $exception->getResponse();
+        $resetTime = $response->getRateLimitReset();
+        
+        // Wait until the rate limit resets and retry
+        sleep($resetTime);
+        // retry the request...
+    }
 }
 ```
 
-When the rate limit is exceeded, the server responds with status code `429 Too Many Requests`. Wait until the rate limit resets (using the value from `getRateLimitReset()`) and then retry the request.
+When the rate limit is exceeded, the server responds with status code `429 Too Many Requests` and throws a `ClientErrorException`. You can check if the exception is due to rate limiting using `isRateLimitExceeded()` method and get rate limit details from the response object.
 
 ## Handling errors
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,72 @@
+# Upgrade Guide
+
+## Upgrading from 4.x to 5.0
+
+### Breaking Changes
+
+#### RequestException::getResponse() return type change
+
+**Changed:** `RequestException::getResponse()` now returns `Fakturoid\Response` instead of `Psr\Http\Message\ResponseInterface`.
+
+**Reason:** This change provides easier access to rate limiting information and other Fakturoid-specific response features.
+
+**Impact:** If you were catching exceptions and using the response object, you may need to update your code.
+
+#### Migration Examples:
+
+**Before (v4.x):**
+```php
+use Fakturoid\Exception\ClientErrorException;
+use Psr\Http\Message\ResponseInterface;
+
+try {
+    $response = $fManager->getInvoicesProvider()->create($data);
+} catch (ClientErrorException $e) {
+    /** @var ResponseInterface $response */
+    $response = $e->getResponse();
+    $statusCode = $response->getStatusCode();
+    $reasonPhrase = $response->getReasonPhrase();
+    $body = $response->getBody()->getContents();
+}
+```
+
+**After (v5.0):**
+```php
+use Fakturoid\Exception\ClientErrorException;
+use Fakturoid\Response;
+
+try {
+    $response = $fManager->getInvoicesProvider()->create($data);
+} catch (ClientErrorException $e) {
+    /** @var Response $response */
+    $response = $e->getResponse();
+    $statusCode = $response->getStatusCode();
+    
+    // Access to PSR ResponseInterface if needed
+    $reasonPhrase = $response->getOriginalResponse()->getReasonPhrase();
+    
+    // Body is now easier to access
+    $body = $response->getBody(); // Returns decoded JSON or string
+    
+    // NEW: Access to rate limiting information
+    if ($e->isRateLimitExceeded()) {
+        $resetTime = $response->getRateLimitReset();
+        $remaining = $response->getRateLimitRemaining();
+    }
+}
+```
+
+#### Key Changes:
+
+1. **Type hint change**: If you were type-hinting `ResponseInterface`, change it to `Response`
+2. **Access to PSR response**: Use `$response->getOriginalResponse()` if you need the original PSR ResponseInterface
+3. **Body access**: `$response->getBody()` now returns decoded JSON (array/object) or string, instead of StreamInterface
+4. **Headers access**: Headers are now accessible via `$response->getHeader('Header-Name')`
+
+## Upgrading from 3.x to 4.0
+
+See [CHANGELOG.md](CHANGELOG.md) for details.
+
+## Upgrading from 2.x to 3.0
+
+See [CHANGELOG.md](CHANGELOG.md) for details.

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   "scripts": {
     "test:phpunit": "php -d xdebug.mode=off vendor/phpunit/phpunit/phpunit",
     "coverage:phpunit": "php -d xdebug.mode=coverage -d memory_limit=512M vendor/phpunit/phpunit/phpunit --coverage-html=coverage --path-coverage",
-    "check:phpstan": "php vendor/bin/phpstan analyse -c phpstan.neon",
+    "check:phpstan": "php -d memory_limit=256M vendor/bin/phpstan analyse -c phpstan.neon",
     "check:rector": "php vendor/bin/rector process src tests --dry-run",
     "check:cs": "phpcs --standard=phpcs.xml",
     "fix:cs": "phpcbf --standard=phpcs.xml",

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -98,7 +98,7 @@ class Dispatcher implements DispatcherInterface
                 ],
                 $body
             );
-            $response = $this->client->sendRequest($request);
+            $response = new Response($this->client->sendRequest($request));
         } catch (ClientExceptionInterface $e) {
             throw new ConnectionFailedException($e->getMessage(), $e->getCode(), $e);
         }
@@ -109,6 +109,6 @@ class Dispatcher implements DispatcherInterface
         if ($responseStatusCode >= 500 && $responseStatusCode < 600) {
             throw new ServerErrorException($request, $response);
         }
-        return new Response($response);
+        return $response;
     }
 }

--- a/src/Exception/ClientErrorException.php
+++ b/src/Exception/ClientErrorException.php
@@ -4,4 +4,8 @@ namespace Fakturoid\Exception;
 
 class ClientErrorException extends RequestException
 {
+    public function isRateLimitExceeded(): bool
+    {
+        return $this->getResponse()->getStatusCode() === 429;
+    }
 }

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -2,19 +2,19 @@
 
 namespace Fakturoid\Exception;
 
+use Fakturoid\Response;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
 class RequestException extends Exception implements RequestExceptionInterface
 {
     public function __construct(
         private readonly RequestInterface $request,
-        private readonly ResponseInterface $response,
+        private readonly Response $response,
         ?Throwable $previous = null
     ) {
-        parent::__construct($response->getReasonPhrase(), $response->getStatusCode(), $previous);
+        parent::__construct($response->getOriginalResponse()->getReasonPhrase(), $response->getStatusCode(), $previous);
     }
 
     public function getRequest(): RequestInterface
@@ -22,7 +22,7 @@ class RequestException extends Exception implements RequestExceptionInterface
         return $this->request;
     }
 
-    public function getResponse(): ResponseInterface
+    public function getResponse(): Response
     {
         return $this->response;
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -50,7 +50,7 @@ class Response
     }
 
     /**
-     * @return string|array<string, mixed>|\stdClass|null
+     * @return ($returnJsonAsArray is true ? array<string, mixed> : \stdClass)|string|null
      * @throws InvalidResponseException
      */
     public function getBody(bool $returnJsonAsArray = false)

--- a/src/Response.php
+++ b/src/Response.php
@@ -12,16 +12,18 @@ class Response
     /** @var array<string, mixed> */
     private readonly array $headers;
     private readonly string $body;
+    private readonly ResponseInterface $originalResponse;
 
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $originalResponse)
     {
         $headers = [];
-        foreach ($response->getHeaders() as $headerName => $value) {
-            $headers[$headerName] = $response->getHeaderLine($headerName);
+        foreach ($originalResponse->getHeaders() as $headerName => $value) {
+            $headers[$headerName] = $originalResponse->getHeaderLine($headerName);
         }
-        $this->statusCode = $response->getStatusCode();
+        $this->statusCode = $originalResponse->getStatusCode();
         $this->headers = $headers;
-        $this->body = $response->getBody()->getContents();
+        $this->body = $originalResponse->getBody()->getContents();
+        $this->originalResponse = $originalResponse;
     }
 
     public function getStatusCode(): int
@@ -32,7 +34,7 @@ class Response
     public function getHeader(string $name): ?string
     {
         foreach ($this->headers as $headerName => $value) {
-            if (strtolower($headerName) == strtolower($name)) {
+            if (strtolower($headerName) === strtolower($name)) {
                 return $value;
             }
         }
@@ -127,8 +129,8 @@ class Response
         return null;
     }
 
-    public function isRateLimitExceeded(): bool
+    public function getOriginalResponse(): ResponseInterface
     {
-        return $this->statusCode === 429;
+        return $this->originalResponse;
     }
 }

--- a/tests/AuthProviderTest.php
+++ b/tests/AuthProviderTest.php
@@ -9,6 +9,7 @@ use Fakturoid\Enum\AuthTypeEnum;
 use Fakturoid\Exception\AuthorizationFailedException;
 use Fakturoid\Exception\ClientErrorException;
 use Fakturoid\Exception\ServerErrorException;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -70,7 +71,7 @@ class AuthProviderTest extends TestCase
 
     public function testAuthorizationCodeReAuth(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -109,7 +110,7 @@ class AuthProviderTest extends TestCase
 
     public function testClientCredentialReAuth(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -148,7 +149,7 @@ class AuthProviderTest extends TestCase
 
     public function testClientCredentialReAuthWithError(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -184,7 +185,7 @@ class AuthProviderTest extends TestCase
 
     public function testClientCredentialReAuthWithoutResponse(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -220,7 +221,7 @@ class AuthProviderTest extends TestCase
 
     public function testClientCredential(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -245,7 +246,7 @@ class AuthProviderTest extends TestCase
 
     public function testClientCredentialWithEmptyResponse(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -274,7 +275,7 @@ class AuthProviderTest extends TestCase
 
     public function testRevoke(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->method('getBody')
             ->willReturn($this->getStreamMock('{}'));
@@ -304,7 +305,7 @@ class AuthProviderTest extends TestCase
 
     public function testRevoke500(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->method('getBody')
             ->willReturn($this->getStreamMock('{}'));
@@ -334,7 +335,7 @@ class AuthProviderTest extends TestCase
 
     public function testRevoke400(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->method('getBody')
             ->willReturn($this->getStreamMock('{}'));
@@ -389,7 +390,7 @@ class AuthProviderTest extends TestCase
 
     public function testAuthorizationCodeSimple(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -420,7 +421,7 @@ class AuthProviderTest extends TestCase
 
     public function testAuthorizationInvalidResponse(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -441,8 +442,7 @@ class AuthProviderTest extends TestCase
 
     public function testAuthorizationInvalidResponse2(): void
     {
-        $exception = new class ('test') extends \Exception implements ClientExceptionInterface
-        {
+        $exception = new class ('test') extends \Exception implements ClientExceptionInterface {
         };
         $client = $this->createMock(ClientInterface::class);
         $client
@@ -457,7 +457,7 @@ class AuthProviderTest extends TestCase
 
     public function testAuthorizationCode(): void
     {
-        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface = $this->getResponseJsonMock();
         $responseInterface
             ->expects($this->once())
             ->method('getBody')
@@ -485,5 +485,20 @@ class AuthProviderTest extends TestCase
         $this->assertEquals('access_token', $credentials->getAccessToken());
         $this->assertEquals('refresh_token', $credentials->getRefreshToken());
         $this->assertEquals(AuthTypeEnum::AUTHORIZATION_CODE_FLOW, $credentials->getAuthType());
+    }
+
+    private function getResponseJsonMock(): MockObject& ResponseInterface
+    {
+        $responseInterface = $this->createMock(ResponseInterface::class);
+        $responseInterface->expects($this->once())
+            ->method('getHeaders')
+            ->willReturn(['Content-Type' => ['application/json']]);
+        $responseInterface
+            ->expects($this->once())
+            ->method('getHeaderLine')
+            ->with('Content-Type')
+            ->willReturn('application/json');
+
+        return $responseInterface;
     }
 }

--- a/tests/InboxFilesProviderTest.php
+++ b/tests/InboxFilesProviderTest.php
@@ -83,6 +83,6 @@ class InboxFilesProviderTest extends TestCase
 
         $provider = new InboxFilesProvider($dispatcher);
         $response = $provider->download($id);
-        $this->assertEquals('binary file', $response->getBody(true));
+        $this->assertEquals('binary file', $response->getBody());
     }
 }

--- a/tests/RequestExceptionTest.php
+++ b/tests/RequestExceptionTest.php
@@ -203,6 +203,79 @@ class RequestExceptionTest extends TestCase
         $dispatcher->patch('/accounts/{accountSlug}/invoices/1.json', ['name' => 'Test']);
     }
 
+    public function test429WithRateLimitHeaders(): void
+    {
+        $responseInterface = $this->createPsrResponseMock(
+            429,
+            'application/json',
+            '{"error":"Rate limit exceeded"}',
+            [
+                'X-RateLimit-Policy' => ['default;q=400;w=60'],
+                'X-RateLimit' => ['default;r=0;t=45']
+            ]
+        );
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn($responseInterface);
+
+        $authProvider = $this->createMock(AuthProvider::class);
+        $credentials = $this->createMock(Credentials::class);
+        $credentials->expects($this->once())
+            ->method('getAccessToken')
+            ->willReturn('test');
+        $authProvider->expects($this->exactly(2))
+            ->method('getCredentials')
+            ->willReturn($credentials);
+
+        $dispatcher = new Dispatcher($authProvider, $client);
+        $dispatcher->setAccountSlug('account-slug');
+
+        try {
+            $dispatcher->patch('/accounts/{accountSlug}/invoices/1.json', ['name' => 'Test']);
+            $this->fail('Expected ClientErrorException was not thrown');
+        } catch (ClientErrorException $e) {
+            $this->assertEquals(429, $e->getCode());
+            $this->assertTrue($e->isRateLimitExceeded());
+
+            // Test rate limit methods on Response object
+            $response = $e->getResponse();
+            $this->assertEquals(400, $response->getRateLimitQuota());
+            $this->assertEquals(60, $response->getRateLimitWindow());
+            $this->assertEquals(0, $response->getRateLimitRemaining());
+            $this->assertEquals(45, $response->getRateLimitReset());
+        }
+    }
+
+    public function test400IsNotRateLimitExceeded(): void
+    {
+        $responseInterface = $this->createPsrResponseMock(400, 'application/json', '{"error":""}');
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn($responseInterface);
+
+        $authProvider = $this->createMock(AuthProvider::class);
+        $credentials = $this->createMock(Credentials::class);
+        $credentials->expects($this->once())
+            ->method('getAccessToken')
+            ->willReturn('test');
+        $authProvider->expects($this->exactly(2))
+            ->method('getCredentials')
+            ->willReturn($credentials);
+
+        $dispatcher = new Dispatcher($authProvider, $client);
+        $dispatcher->setAccountSlug('account-slug');
+
+        try {
+            $dispatcher->patch('/accounts/{accountSlug}/invoices/1.json', ['name' => 'Test']);
+            $this->fail('Expected ClientErrorException was not thrown');
+        } catch (ClientErrorException $e) {
+            $this->assertEquals(400, $e->getCode());
+            $this->assertFalse($e->isRateLimitExceeded());
+        }
+    }
+
     public function testOtherClient(): void
     {
         $responseInterface = $this->createPsrResponseMock(499, 'application/json', '{"error":""}');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -111,41 +111,6 @@ class ResponseTest extends TestCase
         $this->assertEquals(60, $response->getRateLimitWindow());
         $this->assertEquals(398, $response->getRateLimitRemaining());
         $this->assertEquals(55, $response->getRateLimitReset());
-        $this->assertFalse($response->isRateLimitExceeded());
-    }
-
-    public function testRateLimitExceeded(): void
-    {
-        $responseInterface = $this->createMock(ResponseInterface::class);
-        $responseInterface
-            ->expects($this->once())
-            ->method('getStatusCode')
-            ->willReturn(429);
-        $responseInterface
-            ->expects($this->once())
-            ->method('getHeaders')
-            ->willReturn([
-                'X-RateLimit-Policy' => ['default;q=400;w=60'],
-                'X-RateLimit' => ['default;r=0;t=45']
-            ]);
-        $responseInterface
-            ->expects($this->exactly(2))
-            ->method('getHeaderLine')
-            ->willReturnMap([
-                ['X-RateLimit-Policy', 'default;q=400;w=60'],
-                ['X-RateLimit', 'default;r=0;t=45']
-            ]);
-        $responseInterface
-            ->expects($this->once())
-            ->method('getBody')
-            ->willReturn($this->getStreamMock(''));
-
-        $response = new Response($responseInterface);
-
-        $this->assertEquals(429, $response->getStatusCode());
-        $this->assertEquals(0, $response->getRateLimitRemaining());
-        $this->assertEquals(45, $response->getRateLimitReset());
-        $this->assertTrue($response->isRateLimitExceeded());
     }
 
     public function testRateLimitHeadersNotPresent(): void
@@ -170,6 +135,5 @@ class ResponseTest extends TestCase
         $this->assertNull($response->getRateLimitWindow());
         $this->assertNull($response->getRateLimitRemaining());
         $this->assertNull($response->getRateLimitReset());
-        $this->assertFalse($response->isRateLimitExceeded());
     }
 }


### PR DESCRIPTION
- Introduced `isRateLimitExceeded()` method in `ClientErrorException` to check for rate limit status.
- Updated `RequestException` to return `Fakturoid\Response` instead of `Psr\Http\Message\ResponseInterface`, allowing easier access to rate limit information.
- Modified `Response` class to encapsulate the original PSR response and provide methods for rate limit details.
- Updated documentation to reflect breaking changes and new usage patterns.